### PR TITLE
Allow the Rundeck or project administrator to enforce checking out in a project-specific directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ If `yes`, require remote host SSH key is defined in the `~/.ssh/known_hosts` fil
 
 ## GIT Clone Workflow Step
 
-This plugin clone a git repo into a rundeck server folder
+This plugin clone a git repo into a rundeck server folder.
+
+For some use cases, it might be necessary to only allow checking out repositories in directories relative to the Rundeck home directory.
+Allow users to checkout in any location on disk might be a security issue.
+
+The setting `project.plugin.WorkflowStep.git-clone-step.gitUseProjectBasedSubdirectory` (per project) or  `framework.plugin.WorkflowStep.git-clone-step.gitUseProjectBasedSubdirectory` (Rundeck-wide)
+can be set to `true` to enforce this (default is `false`). All values of `Base Directory` will be relative to a project-based subdirectory of the Rundeck home directory (e.g. `/var/lib/rundeck/A_Project`).
 
 ### Configuration
 
@@ -74,7 +80,7 @@ You need to set up the following options to use the plugin:
 
 ### Repo Settings
 
-* **Base Directory**: Directory for checkout
+* **Base Directory**: Directory for checkout. If `project.plugin.WorkflowStep.git-clone-step.gitUseProjectBasedSubdirectory` is set to true in the project configuration, this will be relative to a project-based subdirectory.
 * **Git URL**: Checkout URL.
     See [git-clone](https://www.kernel.org/pub/software/scm/git/docs/git-clone.html)
     specifically the [GIT URLS](https://www.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS) section.

--- a/src/main/groovy/com/rundeck/plugin/GitCloneWorkflowStep.groovy
+++ b/src/main/groovy/com/rundeck/plugin/GitCloneWorkflowStep.groovy
@@ -93,7 +93,7 @@ If `yes`, require remote host SSH key is defined in the `~/.ssh/known_hosts` fil
 
         String localPath
 
-        if (GIT_PROJECT_BASED_SUBDIRECTORY) {
+        if (Boolean.parseBoolean((String) configuration.get(GIT_PROJECT_BASED_SUBDIRECTORY))) {
             String configPath = configuration.get(GIT_BASE_DIRECTORY)
             String project = context.getFrameworkProject()
             Path localPath_p = Paths.get(project, configPath)

--- a/src/main/groovy/com/rundeck/plugin/GitCloneWorkflowStep.groovy
+++ b/src/main/groovy/com/rundeck/plugin/GitCloneWorkflowStep.groovy
@@ -71,7 +71,7 @@ If `yes`, require remote host SSH key is defined in the `~/.ssh/known_hosts` fil
     .property(PropertyUtil.string(GIT_KEY_STORAGE, "SSH Key Path", 'SSH Key Path', false,
                                                                                      null,null,null, renderingOptionsAuthenticationKey))
     .property(PropertyUtil.bool(GIT_PROJECT_BASED_SUBDIRECTORY, "Use per-project subdirectories", "Check repositories out in project-based subdirectories of the Rundeck home directory.",
-    false, "true", PropertyScope.ProjectOnly, renderingOptionsConfig))
+    false, "false", PropertyScope.Project, renderingOptionsConfig))
                                                        .build()
 
     GitCloneWorkflowStep() {


### PR DESCRIPTION
Fixes #3 

Set either in `framework.properties` or the project settings, the flag `project.plugin.WorkflowStep.git-clone-step.gitUseProjectBasedSubdirectory` to `true` (default is `false`) and the _Base Directory_ setting will always be relative to a project-based subdirectory (e.g. MY_PROJECT) in the home directory of Rundeck (even when the setting refers to an absolute path).