### PR TITLE
Added option to hide log output after git clone in rundeck output tab

### DIFF
--- a/src/main/groovy/com/rundeck/plugin/GitCloneWorkflowStep.groovy
+++ b/src/main/groovy/com/rundeck/plugin/GitCloneWorkflowStep.groovy
@@ -6,7 +6,6 @@ import com.dtolabs.rundeck.core.plugins.Plugin
 import com.dtolabs.rundeck.core.plugins.configuration.Describable
 import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyUtil
-import com.dtolabs.rundeck.plugins.PluginLogger
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import com.dtolabs.rundeck.plugins.descriptions.PluginDescription
@@ -29,6 +28,7 @@ class GitCloneWorkflowStep implements StepPlugin, Describable{
 
     public final static String GIT_URL="gitUrl"
     public final static String GIT_BASE_DIRECTORY="gitBaseDirectory"
+    public final static String GIT_LOG_DISABLE ="gitLogDisable"
     public final static String GIT_BRANCH="gitBranch"
     public final static String GIT_HOSTKEY_CHECKING="strictHostKeyChecking"
     public final static String GIT_KEY_STORAGE="gitKeyPath"
@@ -63,6 +63,8 @@ class GitCloneWorkflowStep implements StepPlugin, Describable{
                                                                                      null,null,null, renderingOptionsConfig))
                                                        .property(PropertyUtil.string(GIT_BRANCH, "Branch", "Checkout branch.", true,
                                                                                      "master",null,null, renderingOptionsConfig))
+                                                       .property(PropertyUtil.bool(GIT_LOG_DISABLE, "Disable log output", "Enabling this flag, the plugin will not show the output log", true,
+                                                                                     "false",null, renderingOptionsConfig))
                                                        .property(PropertyUtil.string(GIT_PASSWORD_STORAGE, "Git Password", 'Password to authenticate remotely', false,
                                                                                      null,null,null, renderingOptionsAuthenticationPassword))
                                                        .property(PropertyUtil.select(GIT_HOSTKEY_CHECKING, "SSH: Strict Host Key Checking", '''Use strict host key checking.
@@ -127,11 +129,13 @@ If `yes`, require remote host SSH key is defined in the `~/.ssh/known_hosts` fil
         try{
             gitManager.cloneOrCreate(base)
 
-            def jsonMap = base.listFiles().collect {file ->
-                return [name: file.name, directory: file.directory, file: file.file, path: file.absolutePath]
+            if (!Boolean.parseBoolean((String) configuration.get(GIT_LOG_DISABLE))) {
+                def jsonMap = base.listFiles().collect { file ->
+                    return [name: file.name, directory: file.directory, file: file.file, path: file.absolutePath]
+                }
+                def json = JsonOutput.toJson(jsonMap)
+                logger.log(2, json, meta)
             }
-            def json = JsonOutput.toJson(jsonMap)
-            logger.log(2, json, meta)
 
         }catch(Exception e){
             logger.log(0, e.getMessage())

--- a/src/main/groovy/com/rundeck/plugin/GitResourceModelFactory.groovy
+++ b/src/main/groovy/com/rundeck/plugin/GitResourceModelFactory.groovy
@@ -31,6 +31,7 @@ class GitResourceModelFactory implements ResourceModelSourceFactory,Describable 
 
     public final static String GIT_URL="gitUrl"
     public final static String GIT_BASE_DIRECTORY="gitBaseDirectory"
+    public final static String GIT_LOG_DISABLE ="gitLogDisable"
     public final static String GIT_FILE="gitFile"
     public final static String GIT_FORMAT_FILE="gitFormatFile"
     public final static String GIT_BRANCH="gitBranch"
@@ -66,6 +67,8 @@ Some examples:
             null,null,null, renderingOptionsConfig))
             .property(PropertyUtil.string(GIT_BRANCH, "Branch", "Checkout branch.", true,
             "master",null,null, renderingOptionsConfig))
+            .property(PropertyUtil.bool(GIT_LOG_DISABLE, "Disable log output", "Enabling this flag, the plugin will not show the output log", true,
+            "false",null, renderingOptionsConfig))
             .property(PropertyUtil.string(GIT_FILE, "Resource model File", "Resource model file inside the github repo.", true,
             null,null,null, renderingOptionsConfig))
             .property(PropertyUtil.select(GIT_FORMAT_FILE, "File Format", 'File Format', true,


### PR DESCRIPTION
We are trying to use a custom output of a Rundeck job in HTML format.
In order to do this, we added the option to hide the git plugin feedback.