### PR TITLE
Added the capability to clone and pull SubModules recursively and update JGit version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     compile group: 'org.rundeck', name: 'rundeck-core', version: '2.11.4'
     compile 'org.slf4j:slf4j-api:1.7.30'
 
-    pluginLibs( 'org.eclipse.jgit:org.eclipse.jgit:4.4.0.201606070830-r') {
+    pluginLibs( 'org.eclipse.jgit:org.eclipse.jgit:5.6.0.201912101111-r') {
         exclude module: 'slf4j-api'
         exclude module: 'jsch'
         exclude module: 'commons-logging'


### PR DESCRIPTION
The current version isn't able to pull Submodules, it can be only cloned but will be out of sync because it can't be pulled in subsequent pulls. 

JGit lib version updated.

Fixed the problem that keeps the git repo locked to the java process by closing it.