### PR TITLE
ci: add weekly Monday Snyk scan schedule

### DIFF
--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+  schedule:
+    # Weekly on Monday 06:00 UTC (GitHub Actions cron is UTC-only)
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds `schedule` (Mondays 06:00 UTC) to `snyk-scan.yml` so Snyk runs weekly via the org reusable workflow. No change to scan behavior on push/PR.