### PR TITLE
RUN-4569 Mitigate Jackson CVE-2026-54512/54513

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,13 @@ apply plugin: 'java'
 
 repositories {
     mavenCentral()
+    maven {
+        name = 'Central Portal Snapshots'
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        content {
+            includeGroup('org.rundeck')
+        }
+    }
 }
 
 configurations {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 # Plugins
-axionRelease = "1.18.18"
+axionRelease = "1.21.2"
 nexusPublish = "1.3.0"
 # Libraries
 groovy = "4.0.29"
 junit = "4.13.2"
-rundeckCore = "6.0.0-alpha1-20260407"
+rundeckCore = "6.1.0-SNAPSHOT"
 slf4j = "1.7.36"
 jgit = "6.6.1.202309021850-r"
 jgitSshApache = "6.6.1.202309021850-r"


### PR DESCRIPTION
## Summary
- Bump `rundeck-core` to `6.1.0-SNAPSHOT`, which pulls patched `jackson-databind` 2.22.0 transitively, mitigating CVE-2026-54512 / CVE-2026-54513.
- Standardize the axion-release plugin to 1.21.2.
- Add the Central Portal Snapshots repository so the SNAPSHOT resolves.

## Test plan
- [x] `rundeck-core:6.1.0-SNAPSHOT` and `jackson-databind:2.22.0` resolve on compileClasspath (verified locally).
- [ ] CI build and Snyk scan pass on the branch.