### PR TITLE
RUN-4569 Fix Maven Central publishing endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,10 @@ jar {
 nexusPublishing {
     packageGroup = 'org.rundeck.plugins'
     repositories {
-        sonatype()
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Point `nexusPublishing` at the new Central endpoint (`ossrh-staging-api.central.sonatype.com`) instead of the bare `sonatype()` default, which targets the decommissioned `oss.sonatype.org` and now returns `402`, blocking release publishing.

## Context
The 2.0.1 release (Jackson CVE fix) built and created a GitHub Release, but the "Publish to Maven Central" step failed on `initializeSonatypeStagingRepository` (402). This aligns git-plugin with the other plugin repos' publishing config so a re-released 2.0.1 reaches Maven Central.

## Test plan
- [ ] Merge, then re-tag 2.0.1 to trigger a clean release + Maven Central publish.