### PR TITLE
RUN-4569 Fix git-plugin POM developers for Maven Central

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -40,7 +40,7 @@ publishing {
                     connection = "scm:git:git@github.com/${githubSlug}.git"
                     developerConnection = "scm:git:git@github.com:${githubSlug}.git"
                 }
-                if (project.ext.hasProperty('developers')) {
+                if (project.ext.developers) {
                     developers {
                         project.ext.developers.each { dev ->
                             developer {


### PR DESCRIPTION
## Summary
- Fix the `<developers>` section being omitted from the published POM, which caused `closeSonatypeStagingRepository` to fail Central validation (`400 - Deployment reached an unexpected status: Failed`).
- Root cause: `gradle/publishing.gradle` used `project.ext.hasProperty('developers')`, which checks the `ExtraPropertiesExtension` object for a JavaBean property named `developers` (always false) instead of the dynamic ext property. Changed to `if (project.ext.developers)`, matching the shared/salt-step publishing script.

## Verification
- [x] `generatePomFileForGit-pluginPublication` now emits `<developers>` with `ltamaster` (Luis Toledo).

## Follow-up
- After merge, re-tag `2.0.1` on the fixed commit to re-run the release + Central publish.